### PR TITLE
fix bug in list assignment

### DIFF
--- a/content/011-bash-loops.md
+++ b/content/011-bash-loops.md
@@ -18,7 +18,7 @@ Example:
 ```bash
 #!/bin/bash
 
-users="devdojo, bobby, tony"
+users="devdojo bobby tony"
 
 for user in ${users}
 do


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/bobbyiliev/introduction-to-bash-scripting/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Just a small correction and I guess it is a typo. Using <u>comma</u> in the **users** variable definition renders the output with <u>comma</u> when the items in the list are printed to the console using loop. Removing <u>comma</u> in **users** will fix this bug, since white-space is enough to separate words to be considered as items.

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed