### PR TITLE
PDF file download link fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@
                             <p class="mt-1 mb-4 text-base leading-6 text-gray-500">
                                 Download the Dark theme of the Introduction to Bash Scripting eBook
                             </p>
-                            <a href="https://github.com/bobbyiliev/introduction-to-bash-scripting/blob/main/ebook/en/export/introduction-to-bash-scripting-dark.pdf" class="px-4 py-2 font-semibold text-gray-200 bg-gray-500 border border-green-700 rounded shadow btn btn-secundary hover:bg-gray-600"> Free Download</a>
+                            <a href="https://github.com/bobbyiliev/introduction-to-bash-scripting/raw/main/ebook/en/export/introduction-to-bash-scripting-dark.pdf" class="px-4 py-2 font-semibold text-gray-200 bg-gray-500 border border-green-700 rounded shadow btn btn-secundary hover:bg-gray-600"> Free Download</a>
                         </div>
                     </div>
 
@@ -376,7 +376,7 @@
                             <p class="mt-1 mb-4 text-base leading-6 text-gray-500">
                                 Download the Light theme of the Introduction to Bash Scripting eBook
                             </p>
-                            <a href="https://github.com/bobbyiliev/introduction-to-bash-scripting/blob/main/ebook/en/export/introduction-to-bash-scripting-light.pdf" class="px-4 py-2 font-semibold text-white bg-blue-500 border border-green-700 rounded shadow btn btn-secundary hover:bg-blue-600"> Free Download</a>
+                            <a href="https://github.com/bobbyiliev/introduction-to-bash-scripting/raw/main/ebook/en/export/introduction-to-bash-scripting-light.pdf" class="px-4 py-2 font-semibold text-white bg-blue-500 border border-green-700 rounded shadow btn btn-secundary hover:bg-blue-600"> Free Download</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/bobbyiliev/introduction-to-bash-scripting/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ✓ ] 👷 Optimization

## Description

Hello, when the pdf file download link is clicked instead of downloading it, the user is directed to the GitHub page. So Instead of that I directly pointed them to the raw files so when the download button is clicked the files are directly downloaded, skipping the extra step. Just a minor inconvenience. If you like it you can go ahead and merge it into your project😊
Thank You!

## Added to documentation?

- [ ✓ ] 🙅 no documentation needed
